### PR TITLE
Add a drops / hour component to the panel-items (drop)

### DIFF
--- a/src/components/Drops/Drops.template.html
+++ b/src/components/Drops/Drops.template.html
@@ -61,6 +61,7 @@
       <span class="pinned-drops panel-item-qty font-w700 mr-1" :class="`text-${(drop.qty > 0) ? 'success' : 'danger'}`">{{ drop.qtyText }}</span>
       <img v-if="drop.extraIcon !== undefined" :src="drop.extraIcon" style="margin-left: 0.2rem !important; margin-right: 0.2rem !important;">
       <span class="pinned-drops panel-item-text">{{ drop.label }}</span>
+      <span class="pinned-drops panel-item-drops-hr" v-if="drop.dropsPerHour">{{ drop.dropsPerHour }} / hr</span>
     </div>
     <!-- Delete button -->
     <div class="pinned-drops panel-item-delete text-danger" @click="clickPanelItem(event, 'delete', { id: drop.id })">&times;</div>

--- a/src/components/Drops/Drops.ts
+++ b/src/components/Drops/Drops.ts
@@ -12,6 +12,7 @@ export interface Notif {
   extraIcon?: string;       // Optional extra icon file (e.g. Mastery icon)
   qty: number;              // `notification.args[1]`
   qtyText: string;          // `numberWithCommas(qty)`
+  dropsPerHour?: string;
 }
 
 // Generic type for extra params returned to event handlers, as an object (dict) with arbitrary string keys.
@@ -33,6 +34,7 @@ export interface DropsProps {
   capturePaused: boolean;
   readonly dropdownOptions: object;   // TODO: [Dropdown View Menu]
   dropdownOptionActive: string;       // TODO: [Dropdown View Menu]
+  startTime: number;
 }
 
 interface Drops {
@@ -108,9 +110,23 @@ export function DropsPanelItem(template: string, props: DropsProps, store: any, 
       callback(event.type, action, props, store, extraParams);
     },
 
-    // Handle sorting and filtering
+    // Handle sorting, filtering and adding drop counts per hour
     process(dropCounts) {
       let panelSettings = props.context.settings.section('Panel');
+
+      if (panelSettings.get('show-drops-per-hour')) {
+        const elapsedTimeInHours = (Date.now() - props.startTime) / (1000 * 60 * 60);
+
+        dropCounts.forEach((drop) => {
+          const formatter = new Intl.NumberFormat("en-US", {
+            notation: "compact",
+            compactDisplay: "short",
+            minimumFractionDigits: 0,
+            maximumFractionDigits: 1,
+          });
+          drop.dropsPerHour = formatter.format(drop.qty / elapsedTimeInHours);
+        })
+      }
 
       let sortRule;
       switch (panelSettings.get('panel-sorting')) {

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -74,6 +74,10 @@
   visibility: visible;
 }
 
+.pinned-drops.panel-item-drops-hr {
+  float: right;
+}
+
 .pinned-drops.panel-dropdown.dropdown-menu {
   max-height: 30vh;
   z-index: 99;

--- a/src/ts/setup.ts
+++ b/src/ts/setup.ts
@@ -28,6 +28,7 @@ export async function setup(ctx: Modding.ModContext) {
     capturePaused: false,
     dropdownOptions: {'session': 'Session', 'window': 'Window'},  // TODO: [Dropdown View Menu]
     dropdownOptionActive: 'session',                              // TODO: [Dropdown View Menu]
+    startTime: Date.now()
   };
 
   // Create a store to hold running counts for all drops, shared between components.
@@ -179,6 +180,7 @@ function callbackPanelButtons(eventType: string, action: string, props: DropsPro
       // Reset button
       case 'reset':
         store.clearAllDrops();
+        props.startTime = Date.now();
         break;
       default:
         console.error(`[${props.label}] Unknown button name '${action}'`);
@@ -568,6 +570,17 @@ function createSettings(ctx: Modding.ModContext, dropStore: any) {
 		label: "Show Decimal XP Gains?",
 		hint: "Raw skill XP gains are often decimal numbers which are rounded before being displayed in-game.",
 		default: false,
+    onChange: (newValue: boolean) => {
+      // FIX: This change is not immediate and will only apply when XP is added (`forceRefresh` doesn't work).
+    },
+	});
+
+	sectionPanel.add({
+    type: "switch",
+		name: "show-drops-per-hour",
+		label: "Show Average Drops / hour",
+		hint: "Append a display of average drops per hour.",
+		default: true,
     onChange: (newValue: boolean) => {
       // FIX: This change is not immediate and will only apply when XP is added (`forceRefresh` doesn't work).
     },


### PR DESCRIPTION
Adds estimated drop per hour data to the existing panel items. 
https://i.imgur.com/lLECT9j.png

![image](https://github.com/user-attachments/assets/b40236cf-5ee9-45ea-aeda-67791c36f907)
